### PR TITLE
LibreSSL enforces pkeyopt to come after inkey

### DIFF
--- a/tools/OsEID-tool
+++ b/tools/OsEID-tool
@@ -988,8 +988,8 @@ if [ $LEN -lt 249 ] || [ $RAWSIGN2048 -eq 1 ] ; then
 	if [ $? -eq 0 ]; then
 		echo "testing signature (openssl pkeyutl)"
 		openssl pkeyutl -pubin -verifyrecover \
-			-pkeyopt rsa_padding_mode:none \
 			-inkey tmp/exported_rsa_key.pub \
+			-pkeyopt rsa_padding_mode:none \
 			-in tmp/rsa_sign_testfile_${LEN}.txt.sign \
 			-out tmp/rsa_sign_testfile_${LEN}.txt.check
 		if [ $? -ne 0 ]; then failecho "openssl fail";exit 1;fi
@@ -1061,7 +1061,7 @@ pkcs11-tool --slot-index ${SCSlot} --sign  -m RSA-X-509\
 	--pin 11111111
 if [ $? -eq 0 ]; then
 	echo "testing RSA-X-509 signature (openssl pkeyutl)"
-	openssl pkeyutl -pubin -verifyrecover -inkey tmp/exported_rsa_key.pub -in tmp/rsa_sign_testfile.txt.sign -pkeyopt rsa_padding_mode:none -out tmp/rsa_sign_testfile.txt.sign_verify
+	openssl pkeyutl -pubin -verifyrecover -in tmp/rsa_sign_testfile.txt.sign -inkey tmp/exported_rsa_key.pub -pkeyopt rsa_padding_mode:none -out tmp/rsa_sign_testfile.txt.sign_verify
 	if [ $? -ne 0 ]; then failecho "openssl fail";exit 1;fi
 	cmp tmp/rsa_sign_testfile_x509.txt tmp/rsa_sign_testfile.txt.sign_verify
 	if [ $?	-ne 0 ]; then
@@ -1091,7 +1091,7 @@ pkcs11-tool --slot-index ${SCSlot} --sign  -m RSA-PKCS \
 if [ $? -eq 0 ]; then
 	echo "testing RSA-PKCS signature (openssl pkeyutl)"
 	#openssl rsautl -raw -verify -pubin -inkey tmp/exported_rsa_key.pub < tmp/rsa_sign_testfile.txt.sign > tmp/rsa_sign_testfile.txt.sign_verify
-	openssl pkeyutl -pubin -verifyrecover -inkey tmp/exported_rsa_key.pub -in tmp/rsa_sign_testfile.txt.sign -pkeyopt rsa_padding_mode:none -out tmp/rsa_sign_testfile.txt.sign_verify1
+	openssl pkeyutl -pubin -verifyrecover -in tmp/rsa_sign_testfile.txt.sign -inkey tmp/exported_rsa_key.pub -pkeyopt rsa_padding_mode:none -out tmp/rsa_sign_testfile.txt.sign_verify1
 	if [ $? -ne 0 ]; then failecho "openssl fail";exit 1;fi
 	# create testfile with padding...
 	gawk -b -v LEN=${LEN} '{LEN=LEN-3;LEN=LEN-length($0);printf("%c%c",0,1);for(i=0;i<LEN;i++)printf("%c",255);printf("%c%s",0,$0);exit}' tmp/rsa_sign_testfile_short.txt >tmp/rsa_sign_testfile.txt.sign_verify2
@@ -1160,9 +1160,9 @@ fi
 file_hash=$(mechanism2hash "${MECHANISM}")
 rm -f tmp/rsa_sign_testfile.txt.${file_hash}.sign
 # use pkcs11-tool to do same operation as:
-# openssl pkeyutl -sign -pkeyopt digest:sha1 -pkeyopt rsa_padding_mode:pss -pkeyopt rsa_pss_saltlen:-1 \
+# openssl pkeyutl -sign \
 #	-in tmp/rsa_sign_testfile.txt.sha1 \
-#	-inkey _private_key.pem_ \
+#	-inkey _private_key.pem_ -pkeyopt digest:sha1 -pkeyopt rsa_padding_mode:pss -pkeyopt rsa_pss_saltlen:-1 \
 #	-out tmp/rsa_sign_testfile.txt.sha1.sign
 echo "using pkcs11 interface to sign message, mechanism ${MECHANISM}"
 pkcs11-tool --slot-index ${SCSlot} --sign  -m "${MECHANISM}" \
@@ -1173,10 +1173,10 @@ pkcs11-tool --slot-index ${SCSlot} --sign  -m "${MECHANISM}" \
 if [ $? -eq 0 ]; then
 	openssl pkeyutl -verify -in tmp/rsa_sign_testfile.txt.${file_hash} \
 		 -sigfile tmp/rsa_sign_testfile.txt.${file_hash}.sign \
-		 -pkeyopt rsa_padding_mode:pss \
+         -inkey tmp/exported_rsa_key.pub -pkeyopt rsa_padding_mode:pss \
 		 -pkeyopt rsa_pss_saltlen:-1 \
 		 -pkeyopt digest:${file_hash} \
-		 -pubin -inkey tmp/exported_rsa_key.pub
+		 -pubin
 	if [ $?	-ne 0 ]; then
 		failecho "openssl signature test fail"
 		err=$[$err + 1 ]
@@ -1257,7 +1257,8 @@ if [ $TEST_OAEP == 1 ]; then
  KEY_LEN=`wc -m < tmp/exported_rsa_key.pub`
  # skil small keys (below 1024 bits)
  if [ $KEY_LEN -gt 250 ]; then
-	 openssl pkeyutl -encrypt -pubin -inkey tmp/exported_rsa_key.pub \
+	 openssl pkeyutl -encrypt -pubin \
+        -inkey tmp/exported_rsa_key.pub \
 		-pkeyopt rsa_padding_mode:oaep \
 		-pkeyopt rsa_oaep_md:sha1 \
 		-in tmp/oaep_test.plaintext \


### PR DESCRIPTION
LibreSSL has some more problems, when running the tests, which look like this:
```
using pkcs11 interface to sign message, mechanism SHA256-RSA-PKCS-PSS
Using slot with index 0 (0x0)
Using signature algorithm SHA256-RSA-PKCS-PSS
PSS parameters: hashAlg=SHA256, mgf=MGF1-SHA256, salt_len=32 B
unable to load Private Key
140250766171008:error:09FFF06C:PEM routines:CRYPTO_internal:no start line:pem/pem_lib.c:694:Expecting: ANY PRIVATE KEY
Error initializing context
usage: pkeyutl [-asn1parse] [-certin] [-decrypt] [-derive] [-encrypt]
    [-hexdump] [-in file] [-inkey file] [-keyform fmt]
    [-out file] [-passin arg] [-peerform fmt]
    [-peerkey file] [-pkeyopt opt:value] [-pubin] [-rev]
    [-sigfile file] [-sign] [-verify] [-verifyrecover]

 -asn1parse         ASN.1 parse the output data
 -certin            Input is a certificate containing a public key
 -decrypt           Decrypt the input data using a private key
 -derive            Derive a shared secret using the peer key
 -encrypt           Encrypt the input data using a public key
 -hexdump           Hex dump the output data
 -in file           Input file (default stdin)
 -inkey file        Input key file
 -keyform fmt       Input key format (DER or PEM (default))
 -out file          Output file (default stdout)
 -passin arg        Key password source
 -peerform fmt      Input key format (DER or PEM (default))
 -peerkey file      Peer key file
 -pkeyopt opt:value Public key options
 -pubin             Input is a public key
 -rev               Reverse the input data
 -sigfile file      Signature file (verify operation only)
 -sign              Sign the input data using private key
 -verify            Verify the input data using public key
 -verifyrecover     Verify with public key, recover original data

openssl signature test fail
```
I'm not sure how to fix those other errors, but changing the order of the `openssl` parameters would be an easy fix towards LibreSSL support.